### PR TITLE
Address slice out of range issue in tests

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -183,6 +183,7 @@ impl Database {
                 // parts: ["commit_time", server, owner, repo, time]
                 let key_parts = deserialize_key(key);
                 let time_part = key_parts.last().unwrap();
+
                 // time_part is expected to be a u128
                 let time_nano = u128::from_be_bytes(time_part[..].try_into().unwrap());
                 let time_seconds = time_nano as i64 / NANOSECONDS_PER_SECOND;

--- a/src/database.rs
+++ b/src/database.rs
@@ -183,7 +183,7 @@ impl Database {
                 // parts: ["commit_time", server, owner, repo, time]
                 let key_parts = deserialize_key(key);
                 let time_part = key_parts.last().unwrap();
-                let time_nano = u128::from_be_bytes(time_part[0..16].try_into().unwrap());
+                let time_nano = u128::from_be_bytes(time_part[..].try_into().unwrap());
                 let time_seconds = time_nano as i64 / NANOSECONDS_PER_SECOND;
                 let time = OffsetDateTime::from_unix_timestamp(time_seconds).unwrap();
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -183,6 +183,7 @@ impl Database {
                 // parts: ["commit_time", server, owner, repo, time]
                 let key_parts = deserialize_key(key);
                 let time_part = key_parts.last().unwrap();
+                // time_part is expected to be a u128
                 let time_nano = u128::from_be_bytes(time_part[..].try_into().unwrap());
                 let time_seconds = time_nano as i64 / NANOSECONDS_PER_SECOND;
                 let time = OffsetDateTime::from_unix_timestamp(time_seconds).unwrap();

--- a/src/database.rs
+++ b/src/database.rs
@@ -583,14 +583,14 @@ mod tests {
     fn test_list_commits() {
         let db = Database::new_rocksdb("data/test_list_commits").unwrap();
         let tx = db.transaction();
-        let time = 1234567890;
+        let time_nano = 1234567890 * NANOSECONDS_PER_SECOND as u128;
         let params = CreateCommitParams {
             commit: &"1234567890abcdef".to_string(),
             server: &"github.com".to_string(),
             owner: &"owner".to_string(),
             repo: &"repo".to_string(),
         };
-        tx.create_commit_if_not_exists(time, params).unwrap();
+        tx.create_commit_if_not_exists(time_nano, params).unwrap();
         tx.commit().unwrap();
 
         let commits = db
@@ -602,6 +602,10 @@ mod tests {
             .unwrap();
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].commit, "1234567890abcdef");
+        assert_eq!(
+            commits[0].time_added.unix_timestamp_nanos(),
+            time_nano as i128
+        );
 
         remove_db("data/test_list_commits");
     }


### PR DESCRIPTION
Sometimes there's an error:
```
---- router::tests::list_commits_multiple stdout ----
thread 'router::tests::list_commits_multiple' panicked at 'range end index 16 out of range for slice of length 15', src/database.rs:186:53
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The panic occurs when trying to parse nanosecond from bytes into u128. This PR tries to address it.